### PR TITLE
simplejson & Django 1.7

### DIFF
--- a/ecstatic/manifests.py
+++ b/ecstatic/manifests.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import simplejson as json
 from django.utils.functional import LazyObject
 from django.utils.importlib import import_module
 import os
+import json
 
 
 class NotInManifest(Exception):


### PR DESCRIPTION
[`simplejson` is no longer in](https://docs.djangoproject.com/en/1.7/internals/deprecation/#deprecation-removed-in-1-7) Django per the deprecation timeline.
