### PR TITLE
Use new cache accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /docs/build
+*.pyc
+*.egg-info

--- a/ecstatic/manifests.py
+++ b/ecstatic/manifests.py
@@ -1,5 +1,9 @@
+import django
 from django.conf import settings
-from django.core.cache import get_cache
+if django.VERSION < (1, 7):
+    from django.core.cache import get_cache
+else:
+    from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import LazyObject
 from django.utils.importlib import import_module
@@ -46,7 +50,10 @@ class JsonManifest(object):
     def get(self, key):
         manifest_mtime = os.path.getmtime(settings.ECSTATIC_MANIFEST_FILE)
         cache_key = self._get_cache_key(key, manifest_mtime)
-        cache = get_cache(settings.ECSTATIC_MANIFEST_CACHE)
+        if django.VERSION < (1, 7):
+            cache = get_cache(settings.ECSTATIC_MANIFEST_CACHE)
+        else:
+            cache = caches[settings.ECSTATIC_MANIFEST_CACHE]
         value = cache.get(cache_key)
         if value is None:
             # Populate the cache with the entire contents of the manifest.


### PR DESCRIPTION
@matthewwithanm This PR conditionally uses Django's [new cache accessor](https://docs.djangoproject.com/en/1.7/topics/cache/#django.core.cache.caches). As of Django 1.7, the `get_cache` method was [deprecated in favor of](https://docs.djangoproject.com/en/1.9/releases/1.7/#cache) `caches`. This PR maintains compatibility for Django <= 1.6 by testing the Django version and using `get_cache` when the Django version <= 1.6.

Also, I noted some pretty standard files missing from `.gitignore` so I added them as well.
