### PR TITLE
Use Python's importlib instead of Django's

### DIFF
--- a/ecstatic/manifests.py
+++ b/ecstatic/manifests.py
@@ -6,7 +6,7 @@ else:
     from django.core.cache import caches
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import LazyObject
-from django.utils.importlib import import_module
+from importlib import import_module
 import os
 import json
 


### PR DESCRIPTION
@kenzic [Django 1.9 removes `django.utils.importlib`](https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9). This PR addresses that by using [Python's builtin `importlib`](https://docs.python.org/2/library/importlib.html) instead. This should be fully backwards compatible with older versions of Django while improving support for Django 1.9.